### PR TITLE
introduce interfaces/use_adapter flag to take metrics from Network Adapter

### DIFF
--- a/command/command_windows.go
+++ b/command/command_windows.go
@@ -39,7 +39,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 	if g, err = metricsWindows.NewFilesystemGenerator(conf.Filesystems.Ignore.Regexp); err == nil {
 		generators = append(generators, g)
 	}
-	if g, err = metricsWindows.NewInterfaceGenerator(conf.Interfaces.Ignore.Regexp, metricsInterval); err == nil {
+	if g, err = metricsWindows.NewInterfaceGenerator(conf.Interfaces.Ignore.Regexp, metricsInterval, conf.Interfaces.UseAdapterMetric); err == nil {
 		generators = append(generators, g)
 	}
 	if g, err = metricsWindows.NewDiskGenerator(conf.Disks.Ignore.Regexp, metricsInterval); err == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -385,7 +385,8 @@ type Filesystems struct {
 
 // Interfaces configure intefaces related settings
 type Interfaces struct {
-	Ignore Regexpwrapper `toml:"ignore"`
+	Ignore           Regexpwrapper `toml:"ignore"`
+	UseAdapterMetric bool          `toml:"use_adapter"`
 }
 
 // Regexpwrapper is a wrapper type for marshalling string

--- a/metrics/windows/interface.go
+++ b/metrics/windows/interface.go
@@ -37,7 +37,7 @@ func normalizeName(s string) string {
 }
 
 // NewInterfaceGenerator XXX
-func NewInterfaceGenerator(ignoreReg *regexp.Regexp, interval time.Duration) (*InterfaceGenerator, error) {
+func NewInterfaceGenerator(ignoreReg *regexp.Regexp, interval time.Duration, useAdapterMetric bool) (*InterfaceGenerator, error) {
 	g := &InterfaceGenerator{ignoreReg, interval, 0, nil}
 
 	var err error
@@ -107,10 +107,14 @@ func NewInterfaceGenerator(ignoreReg *regexp.Regexp, interval time.Duration) (*I
 				name = strings.Replace(name, `\`, "_", -1)
 				var counter *windows.CounterInfo
 
+				queryType := "Interface"
+				if useAdapterMetric {
+					queryType = "Adapter"
+				}
 				counter, err = windows.CreateCounter(
 					g.query,
 					fmt.Sprintf(`interface.%s.rxBytes.delta`, escaped),
-					fmt.Sprintf(`\Network Interface(%s)\Bytes Received/sec`, name))
+					fmt.Sprintf(`\Network %s(%s)\Bytes Received/sec`, queryType, name))
 				if err != nil {
 					interfaceLogger.Criticalf(err.Error())
 					return nil, err
@@ -119,7 +123,7 @@ func NewInterfaceGenerator(ignoreReg *regexp.Regexp, interval time.Duration) (*I
 				counter, err = windows.CreateCounter(
 					g.query,
 					fmt.Sprintf(`interface.%s.txBytes.delta`, escaped),
-					fmt.Sprintf(`\Network Interface(%s)\Bytes Sent/sec`, name))
+					fmt.Sprintf(`\Network %s(%s)\Bytes Sent/sec`, queryType, name))
 				if err != nil {
 					interfaceLogger.Criticalf(err.Error())
 					return nil, err


### PR DESCRIPTION
I am using an external switch (bridge) for Hyper-V on Windows and I noticed that agent is not getting the metrics for this network interface correctly and it is always 0.
When I modified to use `Network Adapter` instead of `Network Interface` to get the counters, it works correctly. I've confirmed that I am also able to get the counters for the unbound interface.

Since there is no proof on older Windows, I introduced a flag called `use_adapter` in the `[interfaces]` section to separate the behavior (default is `false`).

Unfortunately, it is very difficult to write this test because it requires actual equipment operation.
I send you parts of the results with `mackerel-agent once`.

### Environment
- `Realtek_PCIe_GbE_Family_Controller` (working with LAN)
- `Intel_R__Wireless-AC_9260_160MHz` (not configured)
- `Hyper-V_Virtual_Ethernet_Adapter__2` (Hyper-V Bridge)

### use_adapter = false (default, current mackerel-agent version behavior)

#### when bridge binds Wireless
```
{
  "interface.Bluetooth_Device__Personal_Area_Network_.rxBytes.delta": 0,
  "interface.Bluetooth_Device__Personal_Area_Network_.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.rxBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.rxBytes.delta": 0, <- Wireless-AC_9260 is bounded to this interface and is disappeared from list
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.txBytes.delta": 0,
  "interface.Realtek_PCIe_GbE_Family_Controller.rxBytes.delta": 8738.94995326181, <- WORKING
  "interface.Realtek_PCIe_GbE_Family_Controller.txBytes.delta": 2834.971611933588
}
```

#### when bridge binds Realtek
```
{
  "interface.Bluetooth_Device__Personal_Area_Network_.rxBytes.delta": 0,
  "interface.Bluetooth_Device__Personal_Area_Network_.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.rxBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.rxBytes.delta": 0, <- BAD. Realtek is dismissed, but no metrics is counted
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.txBytes.delta": 0,
  "interface.Intel_R__Wireless-AC_9260_160MHz.rxBytes.delta": 0,
  "interface.Intel_R__Wireless-AC_9260_160MHz.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.txBytes.delta": 0
}
```

### use_adapter = true

#### when bridge binds Wireless
```
{
  "interface.Bluetooth_Device__Personal_Area_Network_.rxBytes.delta": 0,
  "interface.Bluetooth_Device__Personal_Area_Network_.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.rxBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.rxBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.txBytes.delta": 0,
  "interface.Realtek_PCIe_GbE_Family_Controller.rxBytes.delta": 256.04090960362, <- IT KEEPS WORKING
  "interface.Realtek_PCIe_GbE_Family_Controller.txBytes.delta": 743.408355296997
}
```

#### when bridge binds Realtek
```
{
  "interface.Bluetooth_Device__Personal_Area_Network_.rxBytes.delta": 0,
  "interface.Bluetooth_Device__Personal_Area_Network_.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.rxBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter.txBytes.delta": 0,
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.rxBytes.delta": 550.7985792544075, <- YES! GOT BRIDGE METRICS
  "interface.Hyper-V_Virtual_Ethernet_Adapter__2.txBytes.delta": 1357.3250703055041,
  "interface.Intel_R__Wireless-AC_9260_160MHz.rxBytes.delta": 0,
  "interface.Intel_R__Wireless-AC_9260_160MHz.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter.txBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.rxBytes.delta": 0,
  "interface.Microsoft_Wi-Fi_Direct_Virtual_Adapter__2.txBytes.delta": 0
}
```
